### PR TITLE
Updating Copyright References + Fixing StyleCop Version

### DIFF
--- a/CR.CodeStyle.CSharp.Full.nuspec
+++ b/CR.CodeStyle.CSharp.Full.nuspec
@@ -5,9 +5,9 @@
     <version>0.0.0</version>
     <authors>Jon Bradford</authors>
     <owners>Cognisant Research</owners>
-    <licenseUrl>https://github.com/cognisant/CodeStyle.CSharp/blob/master/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/cognisant/CodeStyle.CSharp/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/cognisant/CodeStyle.CSharp/master/logo.png</iconUrl>
+    <licenseUrl>https://github.com/cognisant/CodeStyle.CSharp.Full/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/cognisant/CodeStyle.CSharp.Full/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/cognisant/CodeStyle.CSharp.Full/master/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The custom ruleset file for Style Cop used at Cognisant Research</description>
     <releaseNotes>Updating Copyright and GitHub References. Updated to StyleCop.Analyzers 1.1.0-beta007.</releaseNotes>

--- a/CR.CodeStyle.CSharp.Full.nuspec
+++ b/CR.CodeStyle.CSharp.Full.nuspec
@@ -10,11 +10,11 @@
     <iconUrl>https://raw.githubusercontent.com/cognisant/CodeStyle.CSharp/master/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The custom ruleset file for Style Cop used at Cognisant Research</description>
-    <releaseNotes>Updating Copyright and GitHub References</releaseNotes>
+    <releaseNotes>Updating Copyright and GitHub References. Updated to StyleCop.Analyzers 1.1.0-beta007.</releaseNotes>
     <copyright>Copyright Research 2018</copyright>
     <tags>Cognisant Stylecop Style cop cr cognisant CR stylecop</tags>
     <dependencies>
-      <dependency id="StyleCop.Analyzers" version="[1.1.0-beta006]" />
+      <dependency id="StyleCop.Analyzers" version="[1.1.0-beta007]" />
     </dependencies>
     <developmentDependency>true</developmentDependency>
   </metadata>

--- a/CR.CodeStyle.CSharp.Full.nuspec
+++ b/CR.CodeStyle.CSharp.Full.nuspec
@@ -4,15 +4,15 @@
     <id>CR.CodeStyle.CSharp.Full</id>
     <version>0.0.0</version>
     <authors>Jon Bradford</authors>
-    <owners>Jon Bradford</owners>
-    <licenseUrl>https://github.com/cognisant/cr-csharp-codestyle/blob/master/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/cognisant/cr-csharp-codestyle</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/cognisant/cr-csharp-codestyle/master/logo.png</iconUrl>
+    <owners>Cognisant Research</owners>
+    <licenseUrl>https://github.com/cognisant/CodeStyle.CSharp/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/cognisant/CodeStyle.CSharp/</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/cognisant/CodeStyle.CSharp/master/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The custom ruleset file for Style Cop used at Cognisant</description>
-    <releaseNotes>Initial Release.</releaseNotes>
-    <copyright>Copyright 2018</copyright>
-    <tags>Cognisant Stylecop Style cop cr</tags>
+    <description>The custom ruleset file for Style Cop used at Cognisant Research</description>
+    <releaseNotes>Updating Copyright and GitHub References</releaseNotes>
+    <copyright>Copyright Research 2018</copyright>
+    <tags>Cognisant Stylecop Style cop cr cognisant CR stylecop</tags>
     <dependencies>
       <dependency id="StyleCop.Analyzers" version="[1.1.0-beta006]" />
     </dependencies>

--- a/CR.CodeStyle.CSharp.Full.nuspec
+++ b/CR.CodeStyle.CSharp.Full.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2018</copyright>
     <tags>Cognisant Stylecop Style cop cr</tags>
     <dependencies>
-      <dependency id="StyleCop.Analyzers" version="1.1.0-beta006" />
+      <dependency id="StyleCop.Analyzers" version="[1.1.0-beta006]" />
     </dependencies>
     <developmentDependency>true</developmentDependency>
   </metadata>

--- a/CR.CodeStyle.CSharp.Full.ruleset
+++ b/CR.CodeStyle.CSharp.Full.ruleset
@@ -66,6 +66,8 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
     <Rule Id="CS1591" Action="None" />
+    <Rule Id="CS1573" Action="None" />
+    <Rule Id="CS1712" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1101" Action="None" />

--- a/CR.CodeStyle.CSharp.Full.ruleset
+++ b/CR.CodeStyle.CSharp.Full.ruleset
@@ -65,9 +65,9 @@
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
-    <Rule Id="CS1591" Action="None" />
-    <Rule Id="CS1573" Action="None" />
-    <Rule Id="CS1712" Action="None" />
+    <Rule Id="CS1591" Action="Hidden" />
+    <Rule Id="CS1573" Action="Hidden" />
+    <Rule Id="CS1712" Action="Hidden" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1101" Action="None" />

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # cr-csharp-codestyle
-The custom ruleset file for Style Cop used at Cognisant
+The custom ruleset file for Style Cop used at Cognisant Research

--- a/stylecop.json
+++ b/stylecop.json
@@ -8,7 +8,7 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Cognisant"
+      "companyName": "Cognisant Research"
     },
     "layoutRules": {
       "newlineAtEndOfFile": "require"


### PR DESCRIPTION
- Updated the company references in the nuspec file to correctly point to Cognisant Research.
- Updated the GitHub links to point to the new repository name.
- Updated the `StyleCop.Analyzers` version string to use a fixed version.