### PR TITLE
Update stylecop release

### DIFF
--- a/CR.CodeStyle.CSharp.Full.nuspec
+++ b/CR.CodeStyle.CSharp.Full.nuspec
@@ -10,11 +10,11 @@
     <iconUrl>https://raw.githubusercontent.com/cognisant/CodeStyle.CSharp.Full/master/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The custom ruleset file for Style Cop used at Cognisant Research</description>
-    <releaseNotes>Updating Copyright and GitHub References. Updated to StyleCop.Analyzers 1.1.0-beta007.</releaseNotes>
-    <copyright>Copyright Research 2018</copyright>
+    <releaseNotes>Updated to the non-beta release version of StyleCop.Analyzers 1.1.118.</releaseNotes>
+    <copyright>Copyright Research 2019</copyright>
     <tags>Cognisant Stylecop Style cop cr cognisant CR stylecop</tags>
     <dependencies>
-      <dependency id="StyleCop.Analyzers" version="[1.1.0-beta007]" />
+      <dependency id="StyleCop.Analyzers" version="[1.1.118]" />
     </dependencies>
     <developmentDependency>true</developmentDependency>
   </metadata>

--- a/CR.CodeStyle.CSharp.Full.template.props
+++ b/CR.CodeStyle.CSharp.Full.template.props
@@ -5,8 +5,8 @@
     <PackageVersion>#.#.#</PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <CodeAnalysisRuleSetLocation Condition=" '$(NuGetPackageRoot)' != '' ">$(NuGetPackageRoot)cr.codestyle.csharp.full\#.#.#</CodeAnalysisRuleSetLocation>
-    <CodeAnalysisRuleSetLocation Condition=" '$(CodeAnalysisRuleSetLocation)' == '' and '$(SolutionDir)' != '' ">$(SolutionDir)packages\cr.codestyle.csharp.full.#.#.#</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition=" '$(NuGetPackageRoot)' != '' ">$(NuGetPackageRoot)\cr.codestyle.csharp.full\#.#.#</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition=" '$(CodeAnalysisRuleSetLocation)' == '' and '$(SolutionDir)' != '' ">$(SolutionDir)\packages\cr.codestyle.csharp.full.#.#.#</CodeAnalysisRuleSetLocation>
     <CodeAnalysisRuleSetLocation Condition=" '$(CodeAnalysisRuleSetLocation)' == '' ">$([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))\packages\cr.codestyle.csharp.full.#.#.#</CodeAnalysisRuleSetLocation>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
- Updated to use StyleCop 1.1.118.
- Updated props file to match StyleCopAnalyzers documentation https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/Configuration.md#sharing-configuration-among-solutions.